### PR TITLE
Fix code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -14,7 +14,7 @@
 
 "use strict";
 
-const { exec } = require("child_process");
+const { execFile } = require("child_process");
 const path = require("path");
 const objectAssign = require("object-assign");
 const debug = require("debug");
@@ -36,7 +36,8 @@ module.exports = function runExec(cmd, opts, cb) {
   let stdout = "";
   let stderr = "";
 
-  const child = exec(cmd, {
+  const [command, ...args] = cmd.split(' ');
+  const child = execFile(command, args, {
     env,
     encoding: "utf-8",
   });


### PR DESCRIPTION
Fixes [https://github.com/Apetree333/bucket-runner/security/code-scanning/2](https://github.com/Apetree333/bucket-runner/security/code-scanning/2)

To fix the problem, we should avoid passing the entire command string to `exec`. Instead, we should use `execFile` or `execFileSync` and pass the command and its arguments separately. This approach ensures that the shell does not interpret any special characters in the arguments, thus preventing command injection.

1. Replace the `exec` call with `execFile`.
2. Split the `cmd` into the command and its arguments.
3. Update the function to handle the new way of executing the command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
